### PR TITLE
Self-daemonize tray app for proper error reporting on launch

### DIFF
--- a/screenprofiler.py
+++ b/screenprofiler.py
@@ -277,7 +277,20 @@ class MainWindow(QWidget):
         dialog.exec_()
 
 if __name__ == '__main__':
+    # Fork to background — parent exits, child continues as the tray app
+    pid = os.fork()
+    if pid > 0:
+        sys.exit(0)
+
+    # Child: detach from terminal and run the tray app
+    os.setsid()
+
+    # Redirect stdout/stderr so the detached process doesn't hold terminal fds
+    devnull = os.open(os.devnull, os.O_RDWR)
+    os.dup2(devnull, sys.stdout.fileno())
+    os.dup2(devnull, sys.stderr.fileno())
+    os.close(devnull)
+
     app = QApplication(sys.argv)
     window = MainWindow()
-    exit_code = app.exec_()
-    sys.exit(exit_code)
+    sys.exit(app.exec_())

--- a/screenprofilercmd.sh
+++ b/screenprofilercmd.sh
@@ -133,11 +133,14 @@ case $command in
         # Change to script directory to ensure correct working directory
         cd "$script_dir" || exit 1
 
-        # Launch the Python tray application in the background
-        # Redirect output to /dev/null to avoid cluttering terminal
-        nohup python3 "$script_dir/screenprofiler.py" >/dev/null 2>&1 &
-
-        print_success "Screen Profiler tray application launched"
+        # The Python script self-daemonizes: it forks, the parent exits
+        # with the appropriate exit code, and the child runs the tray app.
+        if python3 "$script_dir/screenprofiler.py"; then
+            print_success "Screen Profiler tray application launched"
+        else
+            print_error "Failed to launch tray application"
+            exit 1
+        fi
         ;;
 
     # ------------------------------------------------------------------------


### PR DESCRIPTION
`screenprofilercmd tray` silently fails when PyQt5 is missing - `nohup >/dev/null 2>&1 &` swallows all errors.

So instead the python script now forks itself to background, so import/init errors happen before the fork and are shown in terminal.

Works for me.